### PR TITLE
Local Server Push + push intermediates without routes

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,8 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 type (
@@ -220,8 +218,6 @@ func newBuild(config *ProjectConfig, configOrder int, name string, requirements 
 
 		pushHeaders[route] = headers
 	}
-
-	spew.Dump(pushHeaders)
 
 	build := build{
 		name:         name,

--- a/capabilities.go
+++ b/capabilities.go
@@ -120,7 +120,7 @@ func (c capability) String() string {
 	return strings.Join(val, ", ")
 }
 
-func (p *prpl) browserCapabilities(userAgentString string) capability {
+func (p *PRPL) browserCapabilities(userAgentString string) capability {
 	client := p.parser.Parse(userAgentString)
 
 	predicate, ok := browserPredicates[client.UserAgent.Family]

--- a/server.go
+++ b/server.go
@@ -2,7 +2,6 @@ package prpl
 
 import (
 	"bytes"
-	"log"
 	"strings"
 
 	"net/http"
@@ -81,11 +80,6 @@ func (p *PRPL) staticHandler(next http.Handler) http.Handler {
 func (b *build) addHeaders(p *PRPL, w http.ResponseWriter, r *http.Request) {
 	header := w.Header()
 	filename := r.URL.Path
-
-	log.Printf("filename: %q", filename)
-	for f := range b.pushHeaders {
-		log.Printf("f: %q", f)
-	}
 
 	links, ok := b.pushHeaders[filename]
 	if !ok {

--- a/server.go
+++ b/server.go
@@ -2,12 +2,19 @@ package prpl
 
 import (
 	"bytes"
+	"log"
 	"strings"
 
 	"net/http"
 )
 
-func (p *prpl) createHandler() http.Handler {
+var (
+	CacheImmutable    = "public, max-age=31536000, immutable"
+	CacheNever        = "public, max-age=0"
+	CacheNeverPrivate = "private, max-age=0"
+)
+
+func (p *PRPL) createHandler() http.Handler {
 	m := http.NewServeMux()
 
 	for _, build := range p.builds {
@@ -24,7 +31,7 @@ func (p *prpl) createHandler() http.Handler {
 	return m
 }
 
-func (p *prpl) routeHandler(w http.ResponseWriter, r *http.Request) {
+func (p *PRPL) routeHandler(w http.ResponseWriter, r *http.Request) {
 	capabilities := p.browserCapabilities(r.UserAgent())
 	build := p.builds.findBuild(capabilities)
 	if build == nil {
@@ -33,31 +40,36 @@ func (p *prpl) routeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h := w.Header()
-	h.Set("Cache-Control", "public, max-age=0")
-	build.addHeaders(w, h, r.URL.Path)
+	h.Set("Cache-Control", CacheNever)
+	build.addHeaders(p, w, r)
 	build.template.Render(w, r)
 }
 
-func (p *prpl) staticHandler(next http.Handler) http.Handler {
+func (p *PRPL) staticHandler(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		// TODO: Service worker location should be configurable.
 		h := w.Header()
 		if strings.HasSuffix(r.URL.Path, "service-worker.js") {
 			h.Set("Service-Worker-Allowed", "/")
-			h.Set("Cache-Control", "private, max-age=0")
+			h.Set("Cache-Control", CacheNeverPrivate)
 		} else {
-			h.Set("Cache-Control", "public, max-age=31536000, immutable")
+			h.Set("Cache-Control", CacheImmutable)
 		}
+
+		capabilities := p.browserCapabilities(r.UserAgent())
+		build := p.builds.findBuild(capabilities)
+		if build == nil {
+			http.Error(w, "This browser is not supported", http.StatusInternalServerError)
+			return
+		}
+
+		build.addHeaders(p, w, r)
 
 		file, found := files[r.URL.Path]
 		if !found {
 			next.ServeHTTP(w, r)
 			return
 		}
-
-		// TODO: if using original prpl-server-node strategy
-		// add the push headers for *this* push-manifest entry
-		// build.addHeaders(w, h, r.URL.Path)
 
 		content := bytes.NewReader(file.data)
 		http.ServeContent(w, r, r.URL.Path, file.modTime, content)
@@ -66,26 +78,35 @@ func (p *prpl) staticHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-func (b *build) addHeaders(w http.ResponseWriter, header http.Header, filename string) {
-	if links, ok := b.pushHeaders[filename]; ok {
-		// TODO: use actual push if server supports it
-		// need to add content type to push header info
-		// if pusher, ok := w.(http.Pusher); ok {
-		/*
-			for _, url := range headers {
-				pusher.Push(url, &http.PushOptions{
-					Header: http.Header{
-						"Cache-Control": []string{"public, max-age=31536000, immutable"},
-						"Content-Type":  []string{"TODO: file content type here"},
-					},
-				})
-			}
-		*/
-		// } else {
-		// otherwise hope there is a proxy that will do it for us
-		for _, link := range links {
-			header.Add("Link", link)
+func (b *build) addHeaders(p *PRPL, w http.ResponseWriter, r *http.Request) {
+	header := w.Header()
+	filename := r.URL.Path
+
+	log.Printf("filename: %q", filename)
+	for f := range b.pushHeaders {
+		log.Printf("f: %q", f)
+	}
+
+	links, ok := b.pushHeaders[filename]
+	if !ok {
+		links, ok = b.pushHeaders[p.version+filename]
+		if !ok {
+			return
 		}
-		// }
+	}
+
+	if pusher, ok := w.(http.Pusher); ok && p.shouldPush != nil && p.shouldPush(r) {
+		for _, link := range links {
+			pusher.Push(link.file, &http.PushOptions{
+				Header: http.Header{
+					"Cache-Control": []string{CacheImmutable},
+					//"Content-Type":  []string{"TODO: file content type here"},
+				},
+			})
+		}
+	}
+
+	for _, link := range links {
+		header.Add("Link", link.String())
 	}
 }


### PR DESCRIPTION
This adds support for local server pushing instead of just setting the Link header via `WithShouldPush()`.

This also allows for pushing intermediate files without the routes specified. The old behavior was if you had a route `"/foo": "my-foo.html"` and you just requested `my-foo.html` nothing would be pushed. It now pushes on either case which enables most of the benefits of push for routes that aren't known ahead of time.